### PR TITLE
Instrument conversion link analytics

### DIFF
--- a/about.html
+++ b/about.html
@@ -179,8 +179,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/book.html
+++ b/book.html
@@ -135,13 +135,17 @@
       <p class="button-row">
         <a
           class="button button--primary"
-          href="https://www.amazon.com/dp/B0DSXVL84P">
+          href="https://www.amazon.com/dp/B0DSXVL84P"
+          data-evt="book_en_paperback"
+          data-evt-loc="book_page">
           Buy the Paperback
         </a>
 
         <a
           class="button button--secondary"
-          href="https://www.amazon.com/dp/B0DT1N3FFG">
+          href="https://www.amazon.com/dp/B0DT1N3FFG"
+          data-evt="book_en_kindle"
+          data-evt-loc="book_page">
           Buy the Kindle Edition
         </a>
       </p>
@@ -277,7 +281,9 @@
     </p>
 
     <p>
-      <a href="/for-professionals.html">
+      <a href="/for-professionals.html"
+         data-evt="professional_en"
+         data-evt-loc="book_page">
         Professional and Library Information
       </a>
     </p>
@@ -293,8 +299,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/donor-info.html
+++ b/donor-info.html
@@ -152,8 +152,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/donor-testimonials.html
+++ b/donor-testimonials.html
@@ -130,8 +130,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/about.html
+++ b/es/about.html
@@ -176,8 +176,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/book.html
+++ b/es/book.html
@@ -146,13 +146,17 @@
 
           <a
             class="button button--primary"
-            href="https://www.amazon.com/dp/B0GCVN3YJW">
+            href="https://www.amazon.com/dp/B0GCVN3YJW"
+            data-evt="book_es_paperback"
+            data-evt-loc="book_page">
             Comprar la edición de tapa blanda
           </a>
 
           <a
             class="button button--secondary"
-            href="https://www.amazon.com/dp/B0GCTHKNBR">
+            href="https://www.amazon.com/dp/B0GCTHKNBR"
+            data-evt="book_es_kindle"
+            data-evt-loc="book_page">
             Comprar la edición Kindle
           </a>
 
@@ -306,7 +310,9 @@
       </p>
 
       <p>
-        <a href="/es/para-profesionales.html">
+        <a href="/es/para-profesionales.html"
+           data-evt="professional_es"
+           data-evt-loc="book_page">
           Información para profesionales y bibliotecas
         </a>
       </p>
@@ -323,8 +329,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/donor-info.html
+++ b/es/donor-info.html
@@ -162,8 +162,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/donor-testimonials.html
+++ b/es/donor-testimonials.html
@@ -127,8 +127,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/access.html
+++ b/es/hub/dialysis/access.html
@@ -166,8 +166,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/expectations.html
+++ b/es/hub/dialysis/expectations.html
@@ -179,8 +179,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/index.html
+++ b/es/hub/dialysis/index.html
@@ -152,8 +152,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/machine.html
+++ b/es/hub/dialysis/machine.html
@@ -159,8 +159,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/schedule.html
+++ b/es/hub/dialysis/schedule.html
@@ -174,8 +174,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/side-effects.html
+++ b/es/hub/dialysis/side-effects.html
@@ -180,8 +180,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/clinic-administrator.html
+++ b/es/hub/dialysis/staff/clinic-administrator.html
@@ -161,8 +161,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/dietitian.html
+++ b/es/hub/dialysis/staff/dietitian.html
@@ -163,8 +163,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/financial-coordinator.html
+++ b/es/hub/dialysis/staff/financial-coordinator.html
@@ -162,8 +162,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/floor-supervisor.html
+++ b/es/hub/dialysis/staff/floor-supervisor.html
@@ -162,8 +162,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/index.html
+++ b/es/hub/dialysis/staff/index.html
@@ -197,8 +197,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/nephrologist.html
+++ b/es/hub/dialysis/staff/nephrologist.html
@@ -165,8 +165,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/nurse.html
+++ b/es/hub/dialysis/staff/nurse.html
@@ -165,8 +165,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/receptionist.html
+++ b/es/hub/dialysis/staff/receptionist.html
@@ -161,8 +161,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/social-worker.html
+++ b/es/hub/dialysis/staff/social-worker.html
@@ -162,8 +162,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/dialysis/staff/technician.html
+++ b/es/hub/dialysis/staff/technician.html
@@ -169,8 +169,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/donation/index.html
+++ b/es/hub/donation/index.html
@@ -143,8 +143,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/donation/life-after.html
+++ b/es/hub/donation/life-after.html
@@ -122,8 +122,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/donation/recovery.html
+++ b/es/hub/donation/recovery.html
@@ -117,8 +117,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/donation/risks.html
+++ b/es/hub/donation/risks.html
@@ -119,8 +119,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/donation/testing.html
+++ b/es/hub/donation/testing.html
@@ -172,8 +172,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/donation/who-can-donate.html
+++ b/es/hub/donation/who-can-donate.html
@@ -135,8 +135,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/index.html
+++ b/es/hub/index.html
@@ -122,8 +122,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/testimonials/donor-amy.html
+++ b/es/hub/testimonials/donor-amy.html
@@ -171,8 +171,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/testimonials/donor-john.html
+++ b/es/hub/testimonials/donor-john.html
@@ -174,8 +174,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/testimonials/donor-luis.html
+++ b/es/hub/testimonials/donor-luis.html
@@ -243,8 +243,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/testimonials/donor-nancy.html
+++ b/es/hub/testimonials/donor-nancy.html
@@ -180,8 +180,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/index.html
+++ b/es/hub/transplant/index.html
@@ -140,8 +140,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/complications.html
+++ b/es/hub/transplant/postop/complications.html
@@ -147,8 +147,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/index.html
+++ b/es/hub/transplant/postop/index.html
@@ -142,8 +142,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/life-after.html
+++ b/es/hub/transplant/postop/life-after.html
@@ -156,8 +156,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/recovery.html
+++ b/es/hub/transplant/postop/recovery.html
@@ -191,8 +191,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/staff/dietitian.html
+++ b/es/hub/transplant/postop/staff/dietitian.html
@@ -139,8 +139,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/staff/index.html
+++ b/es/hub/transplant/postop/staff/index.html
@@ -137,8 +137,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/staff/nephrologist.html
+++ b/es/hub/transplant/postop/staff/nephrologist.html
@@ -139,8 +139,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/staff/nurse-coordinator.html
+++ b/es/hub/transplant/postop/staff/nurse-coordinator.html
@@ -141,8 +141,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/staff/pharmacist.html
+++ b/es/hub/transplant/postop/staff/pharmacist.html
@@ -140,8 +140,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/postop/staff/social-worker.html
+++ b/es/hub/transplant/postop/staff/social-worker.html
@@ -142,8 +142,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/evaluation.html
+++ b/es/hub/transplant/preop/evaluation.html
@@ -132,8 +132,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/index.html
+++ b/es/hub/transplant/preop/index.html
@@ -132,8 +132,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/matching.html
+++ b/es/hub/transplant/preop/matching.html
@@ -130,8 +130,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/risks.html
+++ b/es/hub/transplant/preop/risks.html
@@ -136,8 +136,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/staff/coordinator.html
+++ b/es/hub/transplant/preop/staff/coordinator.html
@@ -143,8 +143,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/staff/financial-coordinator.html
+++ b/es/hub/transplant/preop/staff/financial-coordinator.html
@@ -140,8 +140,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/staff/index.html
+++ b/es/hub/transplant/preop/staff/index.html
@@ -137,8 +137,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/staff/nephrologist.html
+++ b/es/hub/transplant/preop/staff/nephrologist.html
@@ -138,8 +138,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/staff/social-worker.html
+++ b/es/hub/transplant/preop/staff/social-worker.html
@@ -141,8 +141,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/preop/staff/surgeon.html
+++ b/es/hub/transplant/preop/staff/surgeon.html
@@ -140,8 +140,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/index.html
+++ b/es/hub/transplant/surgery/index.html
@@ -127,8 +127,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/recovery-inpatient.html
+++ b/es/hub/transplant/surgery/recovery-inpatient.html
@@ -168,8 +168,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/staff/anesthesia.html
+++ b/es/hub/transplant/surgery/staff/anesthesia.html
@@ -143,8 +143,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/staff/circulating-nurse.html
+++ b/es/hub/transplant/surgery/staff/circulating-nurse.html
@@ -142,8 +142,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/staff/index.html
+++ b/es/hub/transplant/surgery/staff/index.html
@@ -152,8 +152,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/staff/inpatient-nurse.html
+++ b/es/hub/transplant/surgery/staff/inpatient-nurse.html
@@ -150,8 +150,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/staff/inpatient-tech.html
+++ b/es/hub/transplant/surgery/staff/inpatient-tech.html
@@ -144,8 +144,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/staff/or-nurse.html
+++ b/es/hub/transplant/surgery/staff/or-nurse.html
@@ -142,8 +142,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/staff/pacu-nurse.html
+++ b/es/hub/transplant/surgery/staff/pacu-nurse.html
@@ -145,8 +145,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/staff/physical-therapist.html
+++ b/es/hub/transplant/surgery/staff/physical-therapist.html
@@ -140,8 +140,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/staff/surgeon.html
+++ b/es/hub/transplant/surgery/staff/surgeon.html
@@ -145,8 +145,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/hub/transplant/surgery/surgery.html
+++ b/es/hub/transplant/surgery/surgery.html
@@ -183,8 +183,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/es/index.html
+++ b/es/index.html
@@ -201,7 +201,9 @@
       </p>
 
       <p>
-        <a href="/es/para-profesionales.html">
+        <a href="/es/para-profesionales.html"
+           data-evt="professional_es"
+           data-evt-loc="homepage">
           Información para Profesionales y Bibliotecas
         </a>
       </p>
@@ -217,8 +219,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"
@@ -244,4 +247,3 @@
     <script src="/assets/js/lang-switch.js" defer></script>
 </body>
 </html>
-

--- a/es/para-profesionales.html
+++ b/es/para-profesionales.html
@@ -220,13 +220,17 @@
 
       <ul>
         <li>
-          <a href="https://www.amazon.com/dp/B0GCVN3YJW">
+          <a href="https://www.amazon.com/dp/B0GCVN3YJW"
+             data-evt="book_es_paperback"
+             data-evt-loc="professional_page">
             Edición en tapa blanda en Amazon
           </a>
         </li>
 
         <li>
-          <a href="https://www.amazon.com/dp/B0GCTHKNBR">
+          <a href="https://www.amazon.com/dp/B0GCTHKNBR"
+             data-evt="book_es_kindle"
+             data-evt-loc="professional_page">
             Edición Kindle en Amazon
           </a>
         </li>
@@ -338,8 +342,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/for-professionals.html
+++ b/for-professionals.html
@@ -213,12 +213,16 @@
 
       <ul>
         <li>
-          <a href="https://www.amazon.com/dp/B0DSXVL84P">
+          <a href="https://www.amazon.com/dp/B0DSXVL84P"
+             data-evt="book_en_paperback"
+             data-evt-loc="professional_page">
             English paperback on Amazon
           </a>
         </li>
         <li>
-          <a href="https://www.amazon.com/dp/B0DT1N3FFG">
+          <a href="https://www.amazon.com/dp/B0DT1N3FFG"
+             data-evt="book_en_kindle"
+             data-evt-loc="professional_page">
             English Kindle edition on Amazon
           </a>
         </li>
@@ -312,8 +316,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/access.html
+++ b/hub/dialysis/access.html
@@ -155,8 +155,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/expectations.html
+++ b/hub/dialysis/expectations.html
@@ -168,8 +168,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/index.html
+++ b/hub/dialysis/index.html
@@ -136,8 +136,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/machine.html
+++ b/hub/dialysis/machine.html
@@ -147,8 +147,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/schedule.html
+++ b/hub/dialysis/schedule.html
@@ -163,8 +163,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/side-effects.html
+++ b/hub/dialysis/side-effects.html
@@ -165,8 +165,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/clinic-administrator.html
+++ b/hub/dialysis/staff/clinic-administrator.html
@@ -129,8 +129,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/dietitian.html
+++ b/hub/dialysis/staff/dietitian.html
@@ -130,8 +130,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/financial-coordinator.html
+++ b/hub/dialysis/staff/financial-coordinator.html
@@ -130,8 +130,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/floor-supervisor.html
+++ b/hub/dialysis/staff/floor-supervisor.html
@@ -129,8 +129,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/index.html
+++ b/hub/dialysis/staff/index.html
@@ -172,8 +172,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/nephrologist.html
+++ b/hub/dialysis/staff/nephrologist.html
@@ -132,8 +132,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/nurse.html
+++ b/hub/dialysis/staff/nurse.html
@@ -133,8 +133,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/receptionist.html
+++ b/hub/dialysis/staff/receptionist.html
@@ -129,8 +129,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/social-worker.html
+++ b/hub/dialysis/staff/social-worker.html
@@ -129,8 +129,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/dialysis/staff/technician.html
+++ b/hub/dialysis/staff/technician.html
@@ -136,8 +136,9 @@ I'm going one by one <nav class="sub-nav js-active-nav" aria-label="Dialysis sta
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/donation/index.html
+++ b/hub/donation/index.html
@@ -145,8 +145,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/donation/life-after.html
+++ b/hub/donation/life-after.html
@@ -122,8 +122,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/donation/recovery.html
+++ b/hub/donation/recovery.html
@@ -116,8 +116,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/donation/risks.html
+++ b/hub/donation/risks.html
@@ -118,8 +118,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/donation/testing.html
+++ b/hub/donation/testing.html
@@ -173,8 +173,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/donation/who-can-donate.html
+++ b/hub/donation/who-can-donate.html
@@ -135,8 +135,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/index.html
+++ b/hub/index.html
@@ -123,8 +123,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/testimonials/donor-amy.html
+++ b/hub/testimonials/donor-amy.html
@@ -122,8 +122,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/testimonials/donor-john.html
+++ b/hub/testimonials/donor-john.html
@@ -122,8 +122,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/testimonials/donor-luis.html
+++ b/hub/testimonials/donor-luis.html
@@ -134,8 +134,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/testimonials/donor-nancy.html
+++ b/hub/testimonials/donor-nancy.html
@@ -124,8 +124,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/index.html
+++ b/hub/transplant/index.html
@@ -133,8 +133,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/complications.html
+++ b/hub/transplant/postop/complications.html
@@ -149,8 +149,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/index.html
+++ b/hub/transplant/postop/index.html
@@ -147,8 +147,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/life-after.html
+++ b/hub/transplant/postop/life-after.html
@@ -157,8 +157,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/recovery.html
+++ b/hub/transplant/postop/recovery.html
@@ -195,8 +195,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/staff/dietitian.html
+++ b/hub/transplant/postop/staff/dietitian.html
@@ -141,8 +141,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/staff/index.html
+++ b/hub/transplant/postop/staff/index.html
@@ -140,8 +140,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/staff/nephrologist.html
+++ b/hub/transplant/postop/staff/nephrologist.html
@@ -141,8 +141,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/staff/nurse-coordinator.html
+++ b/hub/transplant/postop/staff/nurse-coordinator.html
@@ -143,8 +143,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/staff/pharmacist.html
+++ b/hub/transplant/postop/staff/pharmacist.html
@@ -143,8 +143,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/postop/staff/social-worker.html
+++ b/hub/transplant/postop/staff/social-worker.html
@@ -145,8 +145,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/evaluation.html
+++ b/hub/transplant/preop/evaluation.html
@@ -143,8 +143,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/index.html
+++ b/hub/transplant/preop/index.html
@@ -127,8 +127,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/matching.html
+++ b/hub/transplant/preop/matching.html
@@ -113,8 +113,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/risks.html
+++ b/hub/transplant/preop/risks.html
@@ -119,8 +119,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/staff/coordinator.html
+++ b/hub/transplant/preop/staff/coordinator.html
@@ -145,8 +145,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/staff/financial-coordinator.html
+++ b/hub/transplant/preop/staff/financial-coordinator.html
@@ -142,8 +142,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/staff/index.html
+++ b/hub/transplant/preop/staff/index.html
@@ -139,8 +139,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/staff/nephrologist.html
+++ b/hub/transplant/preop/staff/nephrologist.html
@@ -141,8 +141,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/staff/social-worker.html
+++ b/hub/transplant/preop/staff/social-worker.html
@@ -141,8 +141,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/preop/staff/surgeon.html
+++ b/hub/transplant/preop/staff/surgeon.html
@@ -142,8 +142,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/index.html
+++ b/hub/transplant/surgery/index.html
@@ -125,8 +125,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/recovery-inpatient.html
+++ b/hub/transplant/surgery/recovery-inpatient.html
@@ -168,8 +168,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/staff/anesthesia.html
+++ b/hub/transplant/surgery/staff/anesthesia.html
@@ -145,8 +145,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/staff/circulating-nurse.html
+++ b/hub/transplant/surgery/staff/circulating-nurse.html
@@ -145,8 +145,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/staff/index.html
+++ b/hub/transplant/surgery/staff/index.html
@@ -156,8 +156,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/staff/inpatient-nurse.html
+++ b/hub/transplant/surgery/staff/inpatient-nurse.html
@@ -153,8 +153,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/staff/inpatient-tech.html
+++ b/hub/transplant/surgery/staff/inpatient-tech.html
@@ -147,8 +147,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/staff/or-nurse.html
+++ b/hub/transplant/surgery/staff/or-nurse.html
@@ -144,8 +144,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/staff/pacu-nurse.html
+++ b/hub/transplant/surgery/staff/pacu-nurse.html
@@ -147,8 +147,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/staff/physical-therapist.html
+++ b/hub/transplant/surgery/staff/physical-therapist.html
@@ -143,8 +143,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/staff/surgeon.html
+++ b/hub/transplant/surgery/staff/surgeon.html
@@ -147,8 +147,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/hub/transplant/surgery/surgery.html
+++ b/hub/transplant/surgery/surgery.html
@@ -185,8 +185,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/includes/footer.html
+++ b/includes/footer.html
@@ -7,8 +7,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"
@@ -29,4 +30,3 @@
 <footer>
   <p>&copy; 2026 Tito. All rights reserved.</p>
 </footer>
-

--- a/includes_es/footer.html
+++ b/includes_es/footer.html
@@ -5,8 +5,9 @@
   atención médica para recibir orientación médica.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/es/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/es/book.html"
+     data-evt="book_es_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"

--- a/index.html
+++ b/index.html
@@ -204,7 +204,9 @@
       </p>
 
       <p>
-        <a href="/for-professionals.html">
+        <a href="/for-professionals.html"
+           data-evt="professional_en"
+           data-evt-loc="homepage">
           Professional and Library Information
         </a>
       </p>
@@ -220,8 +222,9 @@
   healthcare provider for medical guidance.
 </div>
 
-<div class="cta-strip">
-  <a class="button button--primary button--lg" href="/book.html">
+<div class="cta-strip" data-loc="site_footer">
+  <a class="button button--primary button--lg" href="/book.html"
+     data-evt="book_en_info">
     <svg class="button__icon" viewBox="0 0 24 24" width="18" height="18"
      aria-hidden="true" focusable="false">
   <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V5H6.5A2.5 2.5 0 0 0 4 7.5z"
@@ -247,4 +250,3 @@
     <script src="/assets/js/lang-switch.js" defer></script>
 </body>
 </html>
-

--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -4,8 +4,8 @@ document.addEventListener('click', (e) => {
   gtag('event', 'cta_click', {
     cta_id: a.getAttribute('data-evt'),              // e.g., "kofi"
     cta_text: (a.textContent || '').trim(),
-    cta_loc: a.closest('.cta-strip')?.getAttribute('data-loc') || 'unknown',
+    cta_loc: a.getAttribute('data-evt-loc') ||
+      a.closest('[data-loc]')?.getAttribute('data-loc') || 'unknown',
     link_url: a.href
   });
 });
-

--- a/tests/test_analytics.js
+++ b/tests/test_analytics.js
@@ -1,0 +1,51 @@
+const assert = require('node:assert/strict');
+
+let clickHandler;
+const events = [];
+
+global.document = {
+  addEventListener(type, handler) {
+    assert.equal(type, 'click');
+    assert.equal(clickHandler, undefined, 'only one delegated click listener is registered');
+    clickHandler = handler;
+  }
+};
+global.window = { gtag: true };
+global.gtag = (...args) => events.push(args);
+
+require('../scripts/analytics.js');
+
+const trackedLink = {
+  textContent: 'Buy the Paperback',
+  href: 'https://www.amazon.com/dp/B0DSXVL84P',
+  getAttribute(name) {
+    return {
+      'data-evt': 'book_en_paperback',
+      'data-evt-loc': 'book_page'
+    }[name] || null;
+  },
+  closest() {
+    return null;
+  }
+};
+
+clickHandler({
+  target: {
+    closest(selector) {
+      return selector === 'a[data-evt]' ? trackedLink : null;
+    }
+  }
+});
+
+assert.deepEqual(events, [[
+  'event',
+  'cta_click',
+  {
+    cta_id: 'book_en_paperback',
+    cta_text: 'Buy the Paperback',
+    cta_loc: 'book_page',
+    link_url: 'https://www.amazon.com/dp/B0DSXVL84P'
+  }
+]]);
+
+console.log('analytics event contract: pass');

--- a/tests/test_conversion_analytics.py
+++ b/tests/test_conversion_analytics.py
@@ -1,0 +1,79 @@
+import unittest
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AnchorParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.anchors = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            self.anchors.append(dict(attrs))
+
+
+def anchors_for(rel):
+    parser = AnchorParser()
+    parser.feed((ROOT / rel).read_text(encoding="utf-8"))
+    return parser.anchors
+
+
+class ConversionAnalyticsTests(unittest.TestCase):
+    def assert_link(self, rel, href, cta_id, location):
+        matches = [
+            anchor for anchor in anchors_for(rel)
+            if anchor.get("href") == href
+        ]
+        self.assertEqual(1, len(matches), f"expected one {href} link in {rel}")
+        self.assertEqual(cta_id, matches[0].get("data-evt"))
+        self.assertEqual(location, matches[0].get("data-evt-loc"))
+
+    def test_primary_amazon_links_have_stable_ids_and_locations(self):
+        cases = [
+            ("book.html", "https://www.amazon.com/dp/B0DSXVL84P", "book_en_paperback", "book_page"),
+            ("book.html", "https://www.amazon.com/dp/B0DT1N3FFG", "book_en_kindle", "book_page"),
+            ("es/book.html", "https://www.amazon.com/dp/B0GCVN3YJW", "book_es_paperback", "book_page"),
+            ("es/book.html", "https://www.amazon.com/dp/B0GCTHKNBR", "book_es_kindle", "book_page"),
+            ("for-professionals.html", "https://www.amazon.com/dp/B0DSXVL84P", "book_en_paperback", "professional_page"),
+            ("for-professionals.html", "https://www.amazon.com/dp/B0DT1N3FFG", "book_en_kindle", "professional_page"),
+            ("es/para-profesionales.html", "https://www.amazon.com/dp/B0GCVN3YJW", "book_es_paperback", "professional_page"),
+            ("es/para-profesionales.html", "https://www.amazon.com/dp/B0GCTHKNBR", "book_es_kindle", "professional_page"),
+        ]
+        for rel, href, cta_id, location in cases:
+            with self.subTest(rel=rel, href=href):
+                self.assert_link(rel, href, cta_id, location)
+
+    def test_professional_entry_links_are_tracked_in_both_languages(self):
+        self.assert_link("index.html", "/for-professionals.html", "professional_en", "homepage")
+        self.assert_link("book.html", "/for-professionals.html", "professional_en", "book_page")
+        self.assert_link("es/index.html", "/es/para-profesionales.html", "professional_es", "homepage")
+        self.assert_link("es/book.html", "/es/para-profesionales.html", "professional_es", "book_page")
+
+    def test_shared_footer_book_ctas_are_trackable_and_language_specific(self):
+        self.assert_link("includes/footer.html", "/book.html", "book_en_info", None)
+        self.assert_link("includes_es/footer.html", "/es/book.html", "book_es_info", None)
+        for rel in ("includes/footer.html", "includes_es/footer.html"):
+            self.assertIn('data-loc="site_footer"', (ROOT / rel).read_text(encoding="utf-8"))
+
+    def test_analytics_listener_is_single_and_uses_only_link_metadata(self):
+        script = (ROOT / "scripts/analytics.js").read_text(encoding="utf-8")
+        self.assertEqual(1, script.count("document.addEventListener('click'"))
+        self.assertIn("cta_click", script)
+        self.assertIn("data-evt-loc", script)
+        self.assertNotIn("data-email", script)
+        self.assertNotIn("FormData", script)
+
+    def test_ga_loader_appears_once_on_each_conversion_page(self):
+        for rel in ("index.html", "es/index.html", "book.html", "es/book.html",
+                    "for-professionals.html", "es/para-profesionales.html"):
+            with self.subTest(rel=rel):
+                text = (ROOT / rel).read_text(encoding="utf-8")
+                self.assertEqual(1, text.count("googletagmanager.com/gtag/js"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #3 with durable conversion-link instrumentation only.

- Adds stable `cta_id` and meaningful `cta_loc` values to English/Spanish paperback and Kindle Amazon links on Book and Professional/Library pages.
- Instruments English/Spanish Professional/Library entry links on Home and Book pages.
- Instruments persistent bilingual footer Book CTAs through the canonical shared footer sources and regenerates the 132 standalone pages.
- Retains the existing delegated `cta_click` event; adds a link-level location override without changing GA loading or collecting personal data.
- Adds static link-contract coverage and a lightweight runtime event-contract test.

## Event design

| Link type | IDs | Locations |
|---|---|---|
| English purchase | `book_en_paperback`, `book_en_kindle` | `book_page`, `professional_page` |
| Spanish purchase | `book_es_paperback`, `book_es_kindle` | `book_page`, `professional_page` |
| Professional entry | `professional_en`, `professional_es` | `homepage`, `book_page` |
| Persistent Book CTA | `book_en_info`, `book_es_info` | `site_footer` |

Every event retains `cta_click`, visible `cta_text`, and listener-provided `link_url`. No email address, form contents, free text, user ID, or other personal data is added.

## Validation

Passed:

```bash
python3 scripts/expand_includes.py --apply
python3 scripts/update_static_metadata.py --check
python3 scripts/update_structured_data.py --check
python3 scripts/generate_sitemap.py --check
python3 scripts/check_site_integrity.py
node --check scripts/active-link.js
node --check assets/js/lang-switch.js
node --check scripts/analytics.js
node tests/test_analytics.js
python3 -m unittest discover -s tests -v
git diff --check
```

Results:
- Static include generation converged with 0 follow-up updates.
- Integrity checks: 132 standalone pages passed.
- Python unit suite: 14 tests passed.
- Analytics runtime event contract: passed.
- Metadata, structured data, sitemap, JavaScript syntax, and whitespace checks: passed.

## Verification gates

### Pre-merge: automated event-contract testing — required

The automated event-contract test is the pre-merge gate. It verifies that the existing delegated listener emits exactly one `cta_click` with the expected `cta_id`, visible `cta_text`, `cta_loc`, and `link_url`; the static tests also verify durable link coverage and a single GA loader.

### Post-deployment: GA4 DebugView — required

GA4 DebugView verification is required **after deployment**, because the newly instrumented links are not available on production before this PR is merged.

1. Open the deployed site in a Chrome session connected to the intended GA4 DebugView stream (for example, with GA Debugger enabled).
2. Click one English and one Spanish Amazon link, plus one English and one Spanish Professional/Library entry link.
3. Confirm exactly one `cta_click` event per click.
4. Confirm `cta_id`, `cta_text`, `cta_loc`, and `link_url` match the table above.
5. Confirm no event parameters contain an email address, form value, user identifier, or other privacy-sensitive data.

If DebugView shows a missing, duplicated, incorrectly labeled, or privacy-sensitive event, report the failure and do not attempt an unapproved emergency fix.

## Generated files, risk, and rollback

The 132 generated HTML updates are limited to the shared bilingual footer CTA instrumentation. Direct edits are confined to the Home, Book, and Professional/Library conversion links, `scripts/analytics.js`, and tests.

Risk is limited to event labeling; anchors retain their original `href` values and work without JavaScript. Roll back by reverting `c2d1e664afc150dcda8547eaf553565feaf320e8`.

No deployment or merge occurred.

Closes #3
