### PR TITLE
Fix Spanish dialysis staff navigation

### DIFF
--- a/es/hub/dialysis/staff/clinic-administrator.html
+++ b/es/hub/dialysis/staff/clinic-administrator.html
@@ -89,26 +89,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/es/hub/dialysis/staff/dietitian.html
+++ b/es/hub/dialysis/staff/dietitian.html
@@ -89,26 +89,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/es/hub/dialysis/staff/financial-coordinator.html
+++ b/es/hub/dialysis/staff/financial-coordinator.html
@@ -89,26 +89,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/es/hub/dialysis/staff/floor-supervisor.html
+++ b/es/hub/dialysis/staff/floor-supervisor.html
@@ -89,26 +89,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/es/hub/dialysis/staff/index.html
+++ b/es/hub/dialysis/staff/index.html
@@ -85,26 +85,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/es/hub/dialysis/staff/nephrologist.html
+++ b/es/hub/dialysis/staff/nephrologist.html
@@ -91,26 +91,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/es/hub/dialysis/staff/nurse.html
+++ b/es/hub/dialysis/staff/nurse.html
@@ -91,26 +91,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/es/hub/dialysis/staff/receptionist.html
+++ b/es/hub/dialysis/staff/receptionist.html
@@ -89,26 +89,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/es/hub/dialysis/staff/social-worker.html
+++ b/es/hub/dialysis/staff/social-worker.html
@@ -89,26 +89,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/es/hub/dialysis/staff/technician.html
+++ b/es/hub/dialysis/staff/technician.html
@@ -91,26 +91,26 @@
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-subnav.html END -->
       <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html BEGIN -->
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
 <!-- STATIC INCLUDE: /includes_es/dialysis-staff-subnav.html END -->
 

--- a/includes_es/dialysis-staff-subnav.html
+++ b/includes_es/dialysis-staff-subnav.html
@@ -1,23 +1,22 @@
-<nav class="sub-nav js-active-nav" aria-label="Dialysis staff sub-navigation">
-  <a href="/hub/dialysis/staff/index.html" data-prefix="/hub/dialysis/staff/">All Staff</a>
+<nav class="sub-nav js-active-nav" aria-label="Navegación del personal de diálisis">
+  <a href="/es/hub/dialysis/staff/index.html" data-prefix="/es/hub/dialysis/staff/">Roles del personal de la clínica</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nurse.html">Dialysis Nurse (RN)</a>
+  <a href="/es/hub/dialysis/staff/nurse.html">Enfermero/a de diálisis (RN)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/technician.html">Dialysis Tech / PCT</a>
+  <a href="/es/hub/dialysis/staff/technician.html">Técnico/a de diálisis / Técnico/a de atención al paciente (PCT)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/floor-supervisor.html">Floor Supervisor</a>
+  <a href="/es/hub/dialysis/staff/floor-supervisor.html">Supervisor/a de piso / Enfermero/a a cargo</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/nephrologist.html">Nephrologist</a>
+  <a href="/es/hub/dialysis/staff/nephrologist.html">Nefrólogo/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/dietitian.html">Dietitian</a>
+  <a href="/es/hub/dialysis/staff/dietitian.html">Dietista</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/social-worker.html">Social Worker</a>
+  <a href="/es/hub/dialysis/staff/social-worker.html">Trabajador/a social</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/financial-coordinator.html">Financial Coordinator</a>
+  <a href="/es/hub/dialysis/staff/financial-coordinator.html">Coordinador/a financiero/a</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/receptionist.html">Patient Services Coordinator</a>
+  <a href="/es/hub/dialysis/staff/receptionist.html">Coordinador/a de servicios al paciente (Recepción)</a>
   <span class="pipe">|</span>
-  <a href="/hub/dialysis/staff/clinic-administrator.html">Clinic Administrator</a>
+  <a href="/es/hub/dialysis/staff/clinic-administrator.html">Administrador/a de la clínica</a>
 </nav>
-
 

--- a/scripts/check_site_integrity.py
+++ b/scripts/check_site_integrity.py
@@ -49,6 +49,7 @@ class PageParser(HTMLParser):
         self.canonicals = []
         self.alternates = []
         self.links = []
+        self.navigation_links = []
         self.title_parts = []
         self.h1_parts = []
         self.og_title = ""
@@ -60,11 +61,22 @@ class PageParser(HTMLParser):
         self._head_depth = 0
         self._json_parts = None
         self._json_in_head = False
+        self._element_stack = []
+        self._navigation_depth = 0
+        self._language_switch_depth = 0
         self.visible_main_parts = []
 
     def handle_starttag(self, tag, attrs):
         tag = tag.lower()
         attrs = dict(attrs)
+        classes = set(attrs.get("class", "").split())
+        is_navigation = tag == "nav"
+        is_language_switch = "lang-switch" in classes
+        self._element_stack.append((tag, is_navigation, is_language_switch))
+        if is_navigation:
+            self._navigation_depth += 1
+        if is_language_switch:
+            self._language_switch_depth += 1
         if tag == "html":
             self.lang = attrs.get("lang")
         if "id" in attrs:
@@ -83,6 +95,8 @@ class PageParser(HTMLParser):
             self._in_title = True
         if tag == "a" and attrs.get("href"):
             self.links.append(attrs["href"])
+            if self._navigation_depth and not self._language_switch_depth:
+                self.navigation_links.append(attrs["href"])
             if "skip-link" in attrs.get("class", "").split():
                 self.skip_targets.append(attrs["href"])
         if tag == "link":
@@ -99,6 +113,16 @@ class PageParser(HTMLParser):
 
     def handle_endtag(self, tag):
         tag = tag.lower()
+        for index in range(len(self._element_stack) - 1, -1, -1):
+            open_tag, is_navigation, is_language_switch = self._element_stack[index]
+            if open_tag != tag:
+                continue
+            del self._element_stack[index:]
+            if is_navigation:
+                self._navigation_depth -= 1
+            if is_language_switch:
+                self._language_switch_depth -= 1
+            break
         if tag == "title":
             self._in_title = False
         if tag == "h1":
@@ -238,12 +262,33 @@ def check_page(root: Path, rel: Path, pages: set[Path]) -> list[str]:
         errors.append("hreflang alternates do not match the bilingual counterpart")
     if DATA_INCLUDE_RE.search(text):
         errors.append("runtime data-include placeholder remains")
+    errors.extend(check_spanish_navigation_links(rel, parser))
     title_roles = role_in(parser.title) | role_in(parser.og_title)
     h1_roles = role_in(parser.h1)
     if title_roles and h1_roles and title_roles.isdisjoint(h1_roles):
         errors.append("role named by title/metadata conflicts with H1 content")
     errors.extend(check_json_ld(rel, parser))
     return errors
+
+
+def check_spanish_navigation_links(rel: Path, parser: PageParser) -> list[str]:
+    """Reject accidental English hub navigation on Spanish pages.
+
+    Language-switch controls are intentionally excluded while parsing, because
+    they are the one place a Spanish page may deliberately link to English.
+    """
+    if not rel.parts or rel.parts[0] != "es":
+        return []
+    english_hub_links = [
+        href for href in parser.navigation_links
+        if urlsplit(href).path.startswith("/hub/")
+    ]
+    if not english_hub_links:
+        return []
+    return [
+        "Spanish navigation links to English /hub/ routes: "
+        + ", ".join(english_hub_links)
+    ]
 
 
 def resolve_internal_target(root: Path, rel: Path, href: str) -> tuple[Path | None, str | None]:

--- a/tests/test_check_site_integrity.py
+++ b/tests/test_check_site_integrity.py
@@ -76,6 +76,35 @@ class IntegrityCheckTests(unittest.TestCase):
             self.assertIn("hreflang alternates do not match the bilingual counterpart", errors)
             self.assertIn("role named by title/metadata conflicts with H1 content", errors)
 
+    def test_detects_english_hub_navigation_on_spanish_pages_but_allows_language_switch(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            page = self.write(
+                root, Path("es/page.html"),
+                '<h1>Uno</h1><nav><a href="/hub/dialysis/">English hub</a></nav>',
+                lang="es",
+            )
+            errors = integrity.check_spanish_navigation_links(
+                Path("es/page.html"), integrity.parse_page(page)
+            )
+            self.assertEqual(
+                ["Spanish navigation links to English /hub/ routes: /hub/dialysis/"],
+                errors,
+            )
+
+            page = self.write(
+                root, Path("es/page.html"),
+                '<h1>Uno</h1><nav><div class="lang-switch">'
+                '<a href="/hub/dialysis/">EN</a></div></nav>',
+                lang="es",
+            )
+            self.assertEqual(
+                [],
+                integrity.check_spanish_navigation_links(
+                    Path("es/page.html"), integrity.parse_page(page)
+                ),
+            )
+
     def test_detects_sitemap_membership_mismatch(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)


### PR DESCRIPTION
## Summary

Closes #13.

- Localized the canonical `includes_es/dialysis-staff-subnav.html` using the corresponding Spanish staff-page H1 terminology.
- Changed all ten staff-subnavigation destinations and its prefix to `/es/hub/dialysis/staff/`.
- Localized the navigation landmark label to `Navegación del personal de diálisis`.
- Regenerated exactly the ten Spanish dialysis-staff pages that consume the shared include.
- Extended the integrity audit to reject English `/hub/` links inside Spanish navigation while exempting intentional `.lang-switch` links; added unit coverage for both cases.

## Evidence

The new audit reproduced the pre-regeneration defect on exactly these ten generated pages, then passed after regeneration. A repository-wide search and the integrity audit confirm no Spanish page retains an unintended English `/hub/` navigation link.

Rendered local checks confirmed exactly one active link inside the staff subnavigation for all ten affected pages:

- overview, nurse, technician, floor supervisor, nephrologist
- dietitian, social worker, financial coordinator, reception, clinic administrator

A 375px rendered check of the longest technician label showed clean wrapping with no clipping or horizontal overflow. English dialysis-staff pages are unchanged.

## Validation

Passed:

```bash
python3 scripts/expand_includes.py --check
python3 scripts/update_static_metadata.py --check
python3 scripts/update_structured_data.py --check
python3 scripts/generate_sitemap.py --check
python3 scripts/check_site_integrity.py
node --check scripts/active-link.js
node --check assets/js/lang-switch.js
node tests/test_analytics.js
python3 -m unittest discover -s tests -v
git diff --check
git status --short
```

Results: 132 static pages passed include, metadata, structured-data, sitemap, and integrity checks; 15 Python unit tests passed; analytics event-contract and JavaScript syntax checks passed; no generated drift or whitespace errors.

## Changed/generated files

- Canonical source: `includes_es/dialysis-staff-subnav.html`
- Generated output: the ten Spanish dialysis-staff pages only
- Regression coverage: `scripts/check_site_integrity.py` and `tests/test_check_site_integrity.py`

## Risks and rollback

Risk is limited to Spanish dialysis-staff navigation labels and destinations. Roll back by reverting `efc0f03fd7d9e35ea8208a2671b05834fee104fb`; regeneration is deterministic.

## Manual review

Please visually review the Spanish terminology and the shared subnavigation at a normal and narrow viewport. No deployment or merge occurred.